### PR TITLE
Add ':VisualBlock' to vim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -281,3 +281,6 @@ endif
 " Go
 let g:go_fmt_command = 'goimports'
 
+" Commands to access visual block in environments (cough gVim) where <C-v>
+" does paste
+:command! VisualBlock execute "normal! \<C-v>"


### PR DESCRIPTION
For gVim or other GUI vims that bind `<C-v>` to paste